### PR TITLE
switch to clojure 1.2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
 (defproject gaka/gaka "0.2.0"
   :description "A CSS-generating library for Clojure"
-  :dependencies [[org.clojure/clojure "1.2.0-master-SNAPSHOT"]
-                 [org.clojure/clojure-contrib "1.2.0-SNAPSHOT"]]
-  :dev-dependencies [[swank-clojure "1.2.1"]])
+  :dependencies [[org.clojure/clojure "1.2.0"]
+                 [org.clojure/clojure-contrib "1.2.0"]])


### PR DESCRIPTION
Hi Brian,
I propose switching to Clojure 1.2.0 and removing the swank-clojure dev-dependency because of the new leiningen 1.3.0 local dev dependencies feature.
Regards
Fabian
